### PR TITLE
Fix issue #11: ブログの表示日時が作成日になっているので公開日にする

### DIFF
--- a/src/components/ArticlePill.astro
+++ b/src/components/ArticlePill.astro
@@ -28,7 +28,7 @@ const { post } = Astro.props
         </div>
         <div class="c-main__listItemTitle">
             {post.title}
-            <span class="c-main__listItemDate">{formatDate(post.createdAt)}</span>
+            <span class="c-main__listItemDate">{formatDate(post.publishedAt)}</span>
         </div>
     </a>
 </li>

--- a/src/pages/[category]/[post].astro
+++ b/src/pages/[category]/[post].astro
@@ -83,10 +83,10 @@ const formattedContent = $.html()
                 </a>
             </div>
             <div class="c-post__dates">
-                <p class="c-post__createdAt">
-                    {formatDate(post.createdAt)}
+                <p class="c-post__publishedAt">
+                    {formatDate(post.publishedAt)}
                 </p>
-                {post.createdAt !== post.updatedAt && <p class="c-post__updatedAt">{formatDate(post.updatedAt)}</p>}
+                {post.publishedAt !== post.updatedAt && <p class="c-post__updatedAt">{formatDate(post.updatedAt)}</p>}
             </div>
         </div>
         <div class="c-post__contents" set:html={formattedContent} />
@@ -183,12 +183,12 @@ const formattedContent = $.html()
         align-items: flex-end;
     }
 
-    .c-post__createdAt,
+    .c-post__publishedAt,
     .c-post__updatedAt {
         position: relative;
     }
 
-    .c-post__createdAt::before {
+    .c-post__publishedAt::before {
         content: url(/icons/icon-pencil.svg);
         position: absolute;
         top: 60%;


### PR DESCRIPTION
This pull request fixes #11.

The changes replaced all instances of `createdAt` with `publishedAt` in both template displays and CSS styling. Specifically:
1. Updated `post.createdAt` to `post.publishedAt` in the ArticlePill component's date display
2. Changed `createdAt` references to `publishedAt` in the post template's date display and conditional update check
3. Renamed CSS class `.c-post__createdAt` to `.c-post__publishedAt` and updated its pseudo-element styling
These modifications directly address the core requirement to replace `createdAt` with `publishedAt` across display logic and styling.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌